### PR TITLE
Error in markup directive

### DIFF
--- a/config/alfresco/site-webscripts/com/someco/customization/sample-preview-plugin/web-preview.get.html.ftl
+++ b/config/alfresco/site-webscripts/com/someco/customization/sample-preview-plugin/web-preview.get.html.ftl
@@ -1,4 +1,4 @@
-<@markup id="js">
+<@markup id="extd-js" target="js" action="after">
 <#-- JavaScript Dependencies -->
    <@script type="text/javascript" src="${page.url.context}/res/someco/components/preview/PDF.js" group="${dependencyGroup}"></@script>
 </@>


### PR DESCRIPTION
There is an error in the markup directive in the original. The original reads

<@markup id="js">

whereas it should read

<@markup id="extd-js" target="js" action="after">

because you want to add these dependencies after the ones that already exist.
